### PR TITLE
fix: Uncaught ReferenceError: $ is not defined

### DIFF
--- a/dist/js/plugin-node-uiextension.js
+++ b/dist/js/plugin-node-uiextension.js
@@ -1,16 +1,16 @@
-/* global PluginUIExtension, $ */
+/* global PluginUIExtension */
 var PluginUIExtension = {
 
   /**
    * The function defined as the onready callback within the plugin configuration.
    */
   init: function () {
-    var $nav = $('#pl-pattern-nav-target');
-    $nav.prepend(/*NAVLINKS-BEFORE-SNIPPET*/);
-    $nav.append(/*NAVLINKS-AFTER-SNIPPET*/);
+    var nav = document.querySelector('#pl-pattern-nav-target');
+    nav.prepend(/*NAVLINKS-BEFORE-SNIPPET*/);
+    nav.append(/*NAVLINKS-AFTER-SNIPPET*/);
 
-    var $rightList = $('.sg-checklist');
-    $rightList.prepend(/*GEARLINKS-BEFORE-SNIPPET*/);
-    $rightList.find('#sg-find').before(/*GEARLINKS-BEFORESEARCH-SNIPPET*/);
+    var rightList = document.querySelector('.sg-checklist');
+    rightList.prepend(/*GEARLINKS-BEFORE-SNIPPET*/);
+    rightList.querySelector('#sg-find').before(/*GEARLINKS-BEFORESEARCH-SNIPPET*/);
   }
 };

--- a/src/snippet.js
+++ b/src/snippet.js
@@ -1,1 +1,1 @@
-document.createRange().createContextualFragment('<li><a class="<<class>>" target="_blank" rel="external noopener noreferrer" href="<<url>>"><<text>></a>'),
+document.createRange().createContextualFragment('<li><a class="<<class>>" target="_blank" rel="external noopener noreferrer" href="<<url>>"><<text>></a></li>'),

--- a/src/snippet.js
+++ b/src/snippet.js
@@ -1,1 +1,1 @@
-$('<li><a class="<<class>>" target="_blank" rel="external noopener noreferrer" href="<<url>>"><<text>></a>'),
+document.createRange().createContextualFragment('<li><a class="<<class>>" target="_blank" rel="external noopener noreferrer" href="<<url>>"><<text>></a>'),


### PR DESCRIPTION
This would solve the problem described by the issue https://github.com/bmuenzenmeyer/plugin-node-uiextension/issues/14 in the other repository:

> I got the following error with current version:

```
Uncaught ReferenceError: $ is not defined
    at Object.init (plugin-node-uiextension.js:8)
    at eval (eval at init (patternlab-viewer.modern.js:249), <anonymous>:1:33)
    at A (patternlab-viewer.modern.js:254)
    at patternlab-viewer.modern.js:254
    at d (patternlab-viewer.modern.js:254)
    at h (patternlab-viewer.modern.js:254)
    at v (patternlab-viewer.modern.js:254)
    at HTMLScriptElement.l.onload.l.onerror.l.<computed> (patternlab-viewer.modern.js:254)
```