### PR TITLE
refactor: stylesheets path should get defined agnostic to the plugins folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example:
     "initialized": false,
     "options": {
       "stylesheets": [
-        "../../../css/pattern-scaffolding.css"
+        "css/pattern-scaffolding.css"
       ],
       "navLinks": {
         "before": [],

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "stylesheets":["../../../css/pattern-scaffolding.css"],
+  "stylesheets":["css/pattern-scaffolding.css"],
   "navLinks": {
     "before": [],
     "after": []

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function pluginInit(patternlab) {
 
   //write the plugin json to public/patternlab-components
   var pluginConfig = getPluginFrontendConfig();
-  pluginConfig.stylesheets = patternlab.config.plugins[pluginName].options.stylesheets;
+  pluginConfig.stylesheets = patternlab.config.plugins[pluginName].options.stylesheets.map(stylesheet => { return (stylesheet.substr(0, 4).toLowerCase() === 'http') ? stylesheet : path.join("../../../", stylesheet); });
   pluginConfig.navLinks = patternlab.config.plugins[pluginName].options.navLinks;
   pluginConfig.toolLinks = patternlab.config.plugins[pluginName].options.toolLinks;
   writeConfigToOutput(patternlab, pluginConfig);


### PR DESCRIPTION
The stylesheets are currently being inserted into the page via the stylesheet filetype inclusion mechanism by the plugins themselves. That for their path would need to get set relative to the plugins stylesheets folder (actually this plugin doesn't need any stylesheets so far), which is `patternlab-components/@mfranzke/plugin-node-uiextension`.
So any stylesheet path declaration would need to get out of this path and into the root first, like e.g. the current example value declaration would be `/../../../css/pattern-scaffolding.css`.

Including this path because of the underlying implementation via the plugins stylesheets mechanism itself shouldn't be something that the developers have to worry about, it should be intransparent to them. So that for I'd like to suggest to add this reference to the root out of the plugins stylesheets directory programatically.